### PR TITLE
Fix :SwitchBackGround changes colorscheme to default on some colorschemes

### DIFF
--- a/autoload/colorschemes_settings.vim
+++ b/autoload/colorschemes_settings.vim
@@ -133,6 +133,20 @@ function! s:switch_background(
 endfunction
 
 function! g:colorschemes_settings#switch_background()
+  let l:nowcolor = s:get_colors_name()
+  let l:backgrounds = s:get_vim_backgrounds()
+
+  " check inversed background
+  execute "set background=" .. l:backgrounds[1]
+  let l:able_to_inverse = s:get_colors_name() ==# l:nowcolor
+  " restore background and colorscheme
+  execute "set background=" .. l:backgrounds[0]
+  execute "colorscheme " .. l:nowcolor
+
+  if ! l:able_to_inverse
+    echomsg "Cannot inverse background on " .. l:nowcolor
+    return
+  endif
   call s:switch_background(g:colorschemes_settings#rc_file_path)
 endfunction
 


### PR DESCRIPTION
`:SwitchBackGround` force change colorscheme to "default" on colorschemes not supported dark/light backgrounds.

This PR prevents calling to change `background` on non supported.

### 日本語
backgroundのdark/light両方に対応していないカラースキーマで `:SwitchBackGround` による dark/lightの切り替えを行うとcolorschemeが"default"に変わります。

このPRではその問題を解決するため、dark/light両方に対応していないカラースキーマに対して、`background`の変更呼び出しを止めてます。

### issue gif
![issue](https://user-images.githubusercontent.com/22848261/101171203-cabd8b00-3682-11eb-969d-e8a734d202d6.gif)